### PR TITLE
Remove invalid check

### DIFF
--- a/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
+++ b/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
@@ -9,11 +9,6 @@ import org.gradle.api.Project
 class HuaweiPublishPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
-
-        check(project.plugins.hasPlugin("com.android.application")) {
-            "Plugin must be applied to the main app plugin but was applied to ${project.path}"
-        }
-
         project.extensions.create(
             HuaweiPublishExtension.MAIN_EXTENSION_NAME,
             HuaweiPublishExtension::class.java,
@@ -22,17 +17,16 @@ class HuaweiPublishPlugin : Plugin<Project> {
 
         project.afterEvaluate {
             if (!project.plugins.hasPlugin(AppPlugin::class.java)) {
-                project.logger.warn(
-                    "The Android Gradle Plugin was not applied. Gradle Play Publisher " +
-                        "will not be configured.")
+                throw IllegalStateException(
+                    "The Android Gradle Plugin was not applied. Huawei publish will not be configured."
+                )
             }
-        }
-
-        val androidExtension = project.extensions.getByType(AppExtension::class.java)
-        androidExtension.applicationVariants.all { variant ->
-            if (!variant.buildType.isDebuggable) {
-                createTask(project, variant)
-            }
+            project.extensions.getByType(AppExtension::class.java)
+                .applicationVariants.all { variant ->
+                    if (!variant.buildType.isDebuggable) {
+                        createTask(project, variant)
+                    }
+                }
         }
     }
 


### PR DESCRIPTION
The check of the android plugin is not compatible with this [syntax](https://docs.gradle.org/current/userguide/plugins.html#sec:plugins_block) 
It's look like this syntax allow plugin to be applied asynchronously 
````
plugins {
    id "com.android.application"
    id "ru.cian.huawei-publish" version "1.1.0"
}
````

Not sure if I should make a pull request to master or develop. 
If it's develop you should define develop as the default branch in github settings


