### PR TITLE
[NAMING] client key to client secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ File `huawei-credentials.json` contains next json structure:
 ```
 {
   "client_id": "<CLIENT_ID>",
-  "client_key": "<CLIENT_KEY>"
+  "client_secret": "<CLIENT_secret>"
 }
 ```
 Credentials you should get at Huawei AppGallery Developer Console ([Creating an API Client](https://developer.huawei.com/consumer/en/doc/development/AppGallery-connect-Guides/agcapi-getstarted#Creat_Client)).  
@@ -97,7 +97,7 @@ Credentials you should get at Huawei AppGallery Developer Console ([Creating an 
 
 | param           | priority | type    | default value | cli                       | description                                                                                            |
 |-----------------|----------|---------|---------------|---------------------------|--------------------------------------------------------------------------------------------------------|
-| credentialsPath | required | string  | null          | --credentialsPath         | File path with AppGallery credentials params (client_id and client_key)                                |
+| credentialsPath | required | string  | null          | --credentialsPath         | File path with AppGallery credentials params (client_id and client_secret)                             |
 | publish         | optional | boolean | true          | --publish<br>--no-publish | true - upload build file and publish it on all users, <br>false - upload build file without publishing |
 | buildFormat     | optional | string  | "apk"         | --buildFormat             | "apk" or "aab" for corresponding build format                                                          |
 | buildFile       | optional | string  | null          | --buildFile               | Path to build file. "null" means use standard path for "apk" and "aab" files.                          | 

--- a/sample1/huawei-credentials.json
+++ b/sample1/huawei-credentials.json
@@ -1,4 +1,4 @@
 {
   "client_id": "<CLIENT_ID>",
-  "client_key": "<CLIENT_KEY>"
+  "client_secret": "<CLIENT_SECRET>"
 }

--- a/sample2/huawei-credentials-1.json
+++ b/sample2/huawei-credentials-1.json
@@ -1,4 +1,4 @@
 {
   "client_id": "<CLIENT_ID>",
-  "client_key": "<CLIENT_KEY>"
+  "client_secret": "<CLIENT_SECRET>"
 }

--- a/sample2/huawei-credentials-2.json
+++ b/sample2/huawei-credentials-2.json
@@ -1,4 +1,4 @@
 {
   "client_id": "<CLIENT_ID>",
-  "client_key": "<CLIENT_KEY>"
+  "client_secret": "<CLIENT_SECRET>"
 }

--- a/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishTask.kt
+++ b/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishTask.kt
@@ -49,7 +49,7 @@ open class HuaweiPublishTask
     var publish: Boolean? = null
 
     @get:Internal
-    @set:Option(option = "credentialsPath", description = "File path with AppGallery credentials params ('client_id' and 'client_key')")
+    @set:Option(option = "credentialsPath", description = "File path with AppGallery credentials params ('client_id' and 'client_secret')")
     var credentialsPath: String? = null
 
     @get:Internal
@@ -78,7 +78,7 @@ open class HuaweiPublishTask
 
         val credentialsFile = File(credentialsFilePath)
         if (!credentialsFile.exists()) {
-            throw FileNotFoundException("$huaweiPublishExtension (File (${credentialsFile.absolutePath}) with 'client_id' and 'client_key' for access to Huawei Publish API is not found)")
+            throw FileNotFoundException("$huaweiPublishExtension (File (${credentialsFile.absolutePath}) with 'client_id' and 'client_secret' for access to Huawei Publish API is not found)")
         }
 
         val apkBuildFiles = when {
@@ -103,7 +103,7 @@ open class HuaweiPublishTask
         val credentials = getCredentials(credentialsFile)
         val clientId = credentials.clientId.nullIfBlank()
             ?: throw IllegalArgumentException("(Huawei credential `clientId` param is null or empty). Please check your credentials file content.")
-        val clientSecret = credentials.clientKey.nullIfBlank()
+        val clientSecret = credentials.clientSecret.nullIfBlank()
             ?: throw IllegalArgumentException("(Huawei credential `clientSecret` param is null or empty). Please check your credentials file content.")
 
         Logger.i("Get Access Token")

--- a/src/main/kotlin/ru/cian/huawei/publish/models/Credential.kt
+++ b/src/main/kotlin/ru/cian/huawei/publish/models/Credential.kt
@@ -5,6 +5,6 @@ import com.google.gson.annotations.SerializedName
 internal data class Credential(
     @SerializedName("client_id")
     val clientId: String?,
-    @SerializedName("client_key")
-    val clientKey: String?
+    @SerializedName(value = "client_secret", alternate = ["client_key"])
+    val clientSecret: String?
 )


### PR DESCRIPTION
To be more consistent with the API and the AppGallery Connect platform, I propose to change the `client_key` into `client_secret`

Here is a file example download from the AppGallery Connect website.

````
{
	"type":"team_client_id",
	"developer_id":"XXXX",
	"client_id":"XXXX",
	"client_secret":"XXXX",
	"configuration_version":"1.0"
}
````
And here is the parameter of the request
````
        HttpPost post = new HttpPost(domain + "/oauth2/v1/token");
        JSONObject keyString = new JSONObject();
        keyString.put("client_id", "XXXX");
        keyString.put("client_secret", "XXXX");
        keyString.put("grant_type", "client_credentials");
````
