### PR TITLE
Replace 'publish' with 'deployType' parameter

### DIFF
--- a/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishExtension.kt
+++ b/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishExtension.kt
@@ -40,7 +40,7 @@ class HuaweiPublishConfig(
     var credentialsPath: String? = null
     var clientId: String? = null
     var clientSecret: String? = null
-    var publish: Boolean = true
+    var deployType: DeployType = DeployType.PUBLISH
     var publishTimeoutMs: Long? = null
     var publishPeriodMs: Long? = null
     var buildFormat: BuildFormat = BuildFormat.APK
@@ -54,7 +54,7 @@ class HuaweiPublishConfig(
                 "credentialsPath='$credentialsPath', " +
                 "clientId='$clientId', " +
                 "clientSecret='$clientSecret', " +
-                "publish='$publish', " +
+                "deployType='$deployType', " +
                 "publishTimeoutMs='$publishTimeoutMs', " +
                 "publishPeriodMs='$publishPeriodMs', " +
                 "buildFormat='$buildFormat', " +
@@ -83,4 +83,10 @@ open class ReleasePhaseExtension {
 enum class BuildFormat(val fileExtension: String) {
     APK("apk"),
     AAB("aab")
+}
+
+enum class DeployType {
+    PUBLISH,
+    DRAFT,
+    UPLOAD_ONLY
 }


### PR DESCRIPTION
Hi guys! I've faced a problem without an option to only upload files:

After apk uploading plugin calls updateAppFileInformation() method. If we upload apk without (!) publishing to all users then there will be two releases of app in Huawei Connect:
1. Available for all users
2. Draft of release

It's okay and we create a release from a draft with availability for some percent of users. Right after this we've found a bug and we need to upload another version of apk. Then (again, without publishing) we call
```
gradle publishHuaweiAppGallery --no-publish
```
and it throws an exception
```
> Update App File Info is failed. Response: UpdateAppFileInfoResponse(ret=Ret(code=204144647, msg=[cds]update service failed, additional msg is [phased release is on shelf, cannot save or update full release service version!]))
```

So it might be cool to be able in this case to just upload files automated from CI and do other stuff in AppGallery Connect manually