### PR TITLE
Update kotlin version to 1.4.10

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ config.targetSdkVersion=30
 ext.config = config
 
 def versions = [:]
-versions.kotlin = "1.3.72"
+versions.kotlin = "1.4.10"
 versions.java = "1.8"
 ext.versions = versions
 


### PR DESCRIPTION
A little improvement to prevent warnings like 

> Runtime JAR files in the classpath should have the same version
> Consider providing an explicit dependency on some_kotlin_package 1.4 to prevent strange errors

in projects with new kotlin. For now it seems that this really lead to strange errors in out project