### PR TITLE
Add support for Gradle 7.0 and AGP 7.0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,28 @@
+name: All tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        kotlin-version: [1.4.21, 1.5.21]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run tests with Gradle
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: :plugin:test --stacktrace -Pkotlin.version=${{ matrix.kotlin-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # 1.2.4
+
+##### Add
+* Support of Gradle Portal and Gradle DSL..
+
 ##### Breaking changes
 * Removed `clientId` and `clientSecret` plugin extension params as unsecured way for them setting.
+
+##### Fix
+* [issue#21](https://github.com/cianru/huawei-publish-gradle-plugin/issues/21):
+App publication requires additional manual step to be available for users
 
 # 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.2.4
+##### Breaking changes
+* Removed `clientId` and `clientSecret` plugin extension params as unsecured way for them setting.
+
 # 1.2.2
 
 ##### Breaking changes
@@ -5,8 +9,8 @@
 [AGP Issue](https://issuetracker.google.com/issues/109918868/). If you are using APK, then AGP version and Plugin version are irrelevant.
 
 ##### Fix
-* [issue#11](https://github.com/cianru/huawei-publish-gradle-plugin/issues11):
-* [issue#16](https://github.com/cianru/huawei-publish-gradle-plugin/issues16):
+* [issue#11](https://github.com/cianru/huawei-publish-gradle-plugin/issues11): Handle Api Error for wrong `client_id` or `client_secret` values;
+* [issue#16](https://github.com/cianru/huawei-publish-gradle-plugin/issues16): Plugin incorrectly detect AppBundle file location for AGP v4.1.*;
 
 # 1.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.3.0
+
+##### Add
+* [issue#25](https://github.com/cianru/huawei-publish-gradle-plugin/issues/21):
+Gradle 7.0 / Android Gradle Plugin 7.0 support
+* add unit tests to automated github actions
+
 # 1.2.4
 
 ##### Add

--- a/README.md
+++ b/README.md
@@ -109,12 +109,13 @@ pluginManagement {
 }
 ```
 ___
-
 </details>
 
 ## Configuring Plugin
 
-```
+<details open><summary>Groovy</summary>
+
+```groovy
 huaweiPublish {
     instances {
         release {
@@ -130,10 +131,33 @@ huaweiPublish {
     }
 }
 ```
+</details>
+
+<details>
+<summary>Kotlin</summary>
+
+```kotlin
+huaweiPublish {
+    instances {
+        create("release") {
+            credentialsPath = "$rootDir/huawei-credentials-release.json"
+            deployType = ru.cian.huawei.publish.DeployType.DRAFT
+            releasePhase = ru.cian.huawei.publish.ReleasePhaseExtension(
+                startTime = "2025-01-18T21:00:00+0300",
+                endTime = "2025-01-21T06:00:00+0300",
+                percent = 1.0
+            )
+            ...
+        }
+        ...
+    }
+}
+```
+</details>
 
 Plugin supports different settings for different buildType and flavors.
 For example, for `demo` and `full` flavors and `release` buildType just change instances like that:
-```
+```kotlin
 huaweiPublish {
     instances {
         demoRelease {

--- a/README.md
+++ b/README.md
@@ -114,9 +114,7 @@ Where Priority(P), Required(R), Optional(O)
 
 | param            | P | type       | default value | cli                    | description                                                                                                 |
 |------------------|---|------------|---------------|------------------------|-------------------------------------------------------------------------------------------------------------|
-| credentialsPath  | O | string     | null          | --credentialsPath      | File path with AppGallery credentials params (`client_id` and `client_secret`)                              |
-| clientId         | O | string     | null          | --clientId             | `client_id` param from AppGallery credentials. The key more priority than value from `credentialsPath`      |
-| clientSecret     | O | string     | null          | --clientSecret         | `client_secret` param from AppGallery credentials. The key more priority than value from `credentialsPath`  |
+| credentialsPath  | O | string     | null          | --credentialsPath      | Path to json file with AppGallery credentials params (`client_id` and `client_secret`)                      |
 | deployType       | O | string     | "publish"     | --deployType           | '`publish`' to deploy and submit build on users,<br>'`draft`' to deploy and save as draft without submit on users,<br>'`upload-only`' to deploy without draft saving and submit on users|
 | publishTimeoutMs | O | long       | 600000 #(10m) | --publishTimeoutMs     | The time in millis during which the plugin periodically tries to publish the build                          |
 | publishPeriodMs  | O | long       | 15000 #(15s)  | --publishPeriodMs      | The period in millis between tries to publish the build                                                     |
@@ -287,6 +285,10 @@ One more note. If already there is published version that waiting for review you
 For more information see the [Issue#10](https://github.com/cianru/huawei-publish-gradle-plugin/issues/10)
 
 </details>
+
+# Known Huawei Issues
+
+* I use correct `client_id` and `client_secret` but get [Huawei AppGallery Connect API - 403 client token authorization fail](https://stackoverflow.com/questions/63999681/huawei-appgallery-connect-api-403-client-token-authorization-fail)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Huawei App Gallery Publishing
 
 [![Maven Central](https://img.shields.io/maven-central/v/ru.cian/huawei-publish-gradle-plugin.svg)](https://search.maven.org/search?q=a:huawei-publish-gradle-plugin)
-![Version](https://img.shields.io/badge/Version-1.2.2-green.svg)
+![Version](https://img.shields.io/badge/Version-1.2.4-green.svg)
 ![Version](https://img.shields.io/badge/Gradle-4.1.*-pink.svg)
 [![License](https://img.shields.io/github/license/srs/gradle-node-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
@@ -17,16 +17,19 @@ The following features are available:
 * Submit the build on all users after getting store approve
 * Publish the build on a part of users (Release Phases)
 * Separated settings for different configurations build types and flavors
+* Support of Gradle Portal and Gradle DSL.
 
 The following features are missing:
 
-* Support of Gradle Portal and Gradle DSL.
 * Change App Store Information: description, app icon, screenshots and etc.
 * Add Release Notes for publishing build.
+* Support of Gradle 7.+
 
 # Adding the plugin to your project
 
 in application module `./app/build.gradle`
+
+## Using the `apply` method
 
 ```
 buildscript {
@@ -38,6 +41,9 @@ buildscript {
         classpath "ru.cian:huawei-publish-gradle-plugin:<VERSION>"
     }
 }
+
+apply plugin: 'com.android.application'
+apply plugin: 'ru.cian.huawei-publish'
 ```
 <details>
 <summary>Snapshot builds are also available</summary>
@@ -56,15 +62,59 @@ buildscript {
         classpath "ru.cian:huawei-publish-gradle-plugin:<VERSION>-SNAPSHOT"
     }
 }
+
+apply plugin: 'com.android.application'
+apply plugin: 'ru.cian.huawei-publish'
 ```
 ___
 
 </details>
 
-```
-apply plugin: 'com.android.application'
-apply plugin: 'ru.cian.huawei-publish'
+## Using the Gradle plugin DSL
 
+```
+plugins {
+    id("com.android.application")
+    id("ru.cian.huawei-publish")
+}
+```
+
+<details>
+<summary>Snapshot builds are also available</summary>
+___
+
+You'll need to add the Sonatype snapshots repository.
+Look for the actual version of the snapshot in the name of the opened `snapshot-<VERSION>` repository branch.
+
+in `./settings.gradle`
+
+```kotlin
+pluginManagement {
+
+    resolutionStrategy {
+        eachPlugin {
+            if(requested.id.namespace == "ru.cian") {
+                useModule("ru.cian:huawei-publish-gradle-plugin:<SNAPSHOT-VERSION>")
+            }
+        }
+    }
+
+    plugins {
+        id("ru.cian.huawei-publish") version huaweiPublish apply false
+    }
+
+    repositories {
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    }
+}
+```
+___
+
+</details>
+
+## Configuring Plugin
+
+```
 huaweiPublish {
     instances {
         release {
@@ -117,7 +167,7 @@ Where Priority(P), Required(R), Optional(O)
 | credentialsPath  | O | string     | null          | --credentialsPath      | Path to json file with AppGallery credentials params (`client_id` and `client_secret`)                      |
 | deployType       | O | string     | "publish"     | --deployType           | '`publish`' to deploy and submit build on users,<br>'`draft`' to deploy and save as draft without submit on users,<br>'`upload-only`' to deploy without draft saving and submit on users|
 | publishTimeoutMs | O | long       | 600000 #(10m) | --publishTimeoutMs     | The time in millis during which the plugin periodically tries to publish the build                          |
-| publishPeriodMs  | O | long       | 15000 #(15s)  | --publishPeriodMs      | The period in millis between tries to publish the build                                                     |
+| publishPeriodMs  | O | long       | 15000  #(15s) | --publishPeriodMs      | The period in millis between tries to publish the build                                                     |
 | buildFormat      | O | string     | "apk"         | --buildFormat          | 'apk' or 'aab' for corresponding build format                                                               |
 | buildFile        | O | string     | null          | --buildFile            | Path to build file. "null" means use standard path for "apk" and "aab" files.                               |
 | releaseTime      | O | string     | null          | --releaseTime          | Release time after review in UTC format. The format is 'yyyy-MM-dd'T'HH:mm:ssZZ'.                           |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/ru.cian/huawei-publish-gradle-plugin.svg)](https://search.maven.org/search?q=a:huawei-publish-gradle-plugin)
 ![Version](https://img.shields.io/badge/Version-1.2.4-green.svg)
-![Version](https://img.shields.io/badge/Gradle-4.1.*-pink.svg)
+![Version](https://img.shields.io/badge/Gradle-7.0.*-pink.svg)
 [![License](https://img.shields.io/github/license/srs/gradle-node-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 The plugin allows you to publish the android release build file (*.apk or *.aab) to the Huawei AppGallery.
@@ -18,12 +18,12 @@ The following features are available:
 * Publish the build on a part of users (Release Phases)
 * Separated settings for different configurations build types and flavors
 * Support of Gradle Portal and Gradle DSL.
+* Support of Gradle 7.+
 
 The following features are missing:
 
 * Change App Store Information: description, app icon, screenshots and etc.
 * Add Release Notes for publishing build.
-* Support of Gradle 7.+
 
 # Adding the plugin to your project
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -75,14 +75,6 @@ plugins.gradle.org.
    ```bash
    ./gradlew clean check
    ```
-1. Make a *signed* commit:
-   ```bash
-   git commit -S -m "Release vX.Y.Z"
-   ``` 
-1. Make a *signed* tag (check existing tags for message format):
-   ```bash
-   git tag -s -a X.Y.Z
-   ```
 1. Upload binaries to Sonatype:
    ```bash
    ./gradlew publishHuaweiPublicationToMavenRepository
@@ -102,6 +94,7 @@ plugins.gradle.org.
     ```
     cd ./plugin
     ```
+1. Edit gradle.properties, remove '-SNAPSHOT' from the VERSION property
 1. Upload binaries to Bintray:
    ```bash
    ./gradlew build bintrayUpload
@@ -115,16 +108,34 @@ plugins.gradle.org.
     ```
     cd ./plugin
     ```
+1. Edit gradle.properties, remove '-SNAPSHOT' from the VERSION property
 1. Upload binaries to Gradle's plugin portal:
    ```bash
    ./gradlew publishPlugins
    ```
-1. Edit gradle.properties, bump the version number and add '-SNAPSHOT'
+1. Check uploaded files and version Gradle Plugin Portal site: https://plugins.gradle.org/
+
+########################################################################
+### Prepare Release Commit
+########################################################################
+1. Edit gradle.properties, remove '-SNAPSHOT' from the VERSION property
 1. Make a *signed* commit:
    ```bash
-   git commit -S -m "Prepare next development version"
+   git commit -m "Release vX.Y.Z"
+   ```
+1. Make a *signed* tag (check existing tags for message format):
+   ```bash
+   git tag -s -a "vX.Y.Z"
    ```
 1. Push all of our work to Github to make it official:
    ```bash
    git push --tags origin master
+
+########################################################################
+### Prepare Next Snapshot Version Commit
+########################################################################
+1. Edit gradle.properties, bump the version number and add '-SNAPSHOT'
+1. Make a *signed* commit:
+   ```bash
+   git commit -m "Prepare next development version"
    ```

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
         libs.kotlinStdlib,
         libs.kotlinReflect,
         libs.gson,
+        libs.okhttp,
     )
 
     compileOnly (

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@ libs.kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
 libs.kotlinReflect = "org.jetbrains.kotlin:kotlin-reflect:$versions.kotlin"
 libs.gson = "com.google.code.gson:gson:2.8.2"
 libs.okhttp = "com.squareup.okhttp3:okhttp:4.9.1"
-libs.gradleTools = "com.android.tools.build:gradle:4.1.1"
+libs.gradleTools = "com.android.tools.build:gradle:7.0.0"
 
 def junit = [:]
 versions.junitJupiter = "5.7.0"
@@ -33,7 +33,7 @@ ext.junit = junit
 ext.libs = libs
 
 def gradlePlugins = [:]
-gradlePlugins.gradle = "com.android.tools.build:gradle:4.1.3"
+gradlePlugins.gradle = "com.android.tools.build:gradle:7.0.0"
 gradlePlugins.kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
 gradlePlugins.dokka = "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
 gradlePlugins.maven = "com.github.dcendents:android-maven-gradle-plugin:2.1"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,7 +32,7 @@ ext.junit = junit
 ext.libs = libs
 
 def gradlePlugins = [:]
-gradlePlugins.gradle = "com.android.tools.build:gradle:4.1.1"
+gradlePlugins.gradle = "com.android.tools.build:gradle:4.1.3"
 gradlePlugins.kotlin = "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
 gradlePlugins.dokka = "org.jetbrains.dokka:dokka-gradle-plugin:0.10.1"
 gradlePlugins.maven = "com.github.dcendents:android-maven-gradle-plugin:2.1"
@@ -42,5 +42,5 @@ gradlePlugins.publish = "com.gradle.publish:plugin-publish-plugin:0.12.0"
 ext.gradlePlugins = gradlePlugins
 
 def sample = [:]
-sample.huaweiPlugin = "1.2.2-SNAPSHOT"
+sample.huaweiPlugin = "1.2.4-SNAPSHOT"
 ext.sample = sample

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,6 +15,7 @@ libs.appcompat = "androidx.appcompat:appcompat:1.2.0"
 libs.kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
 libs.kotlinReflect = "org.jetbrains.kotlin:kotlin-reflect:$versions.kotlin"
 libs.gson = "com.google.code.gson:gson:2.8.2"
+libs.okhttp = "com.squareup.okhttp3:okhttp:4.9.1"
 libs.gradleTools = "com.android.tools.build:gradle:4.1.1"
 
 def junit = [:]

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,5 +2,6 @@ org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 kotlin.code.style=official
 org.gradle.parallel=false
 
-android.useAndroidX=true
-android.enableJetifier=true
+android.useAndroidX=false
+android.enableJetifier=false
+

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Sun Dec 27 15:37:46 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -83,6 +83,7 @@ dependencies {
             junit.mockitoKotlin,
             junit.hamcreast,
             junit.assertk,
+            libs.gradleTools,
     )
 
 }
@@ -98,4 +99,8 @@ compileTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -67,6 +67,7 @@ dependencies {
             libs.kotlinStdlib,
             libs.kotlinReflect,
             libs.gson,
+            libs.okhttp,
     )
 
     compileOnly (

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -8,7 +8,7 @@ android.enableJetifier=true
 ####################################################################################################
 
 GROUP=ru.cian
-VERSION_NAME=1.2.2
+VERSION_NAME=1.2.4-SNAPSHOT
 
 POM_ARTIFACT_ID=huawei-publish-gradle-plugin
 POM_NAME=Huawei Publish Gradle Plugin

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -8,7 +8,7 @@ android.enableJetifier=true
 ####################################################################################################
 
 GROUP=ru.cian
-VERSION_NAME=1.2.4-SNAPSHOT
+VERSION_NAME=1.2.4
 
 POM_ARTIFACT_ID=huawei-publish-gradle-plugin
 POM_NAME=Huawei Publish Gradle Plugin

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -8,7 +8,7 @@ android.enableJetifier=true
 ####################################################################################################
 
 GROUP=ru.cian
-VERSION_NAME=1.2.4
+VERSION_NAME=1.3.0
 
 POM_ARTIFACT_ID=huawei-publish-gradle-plugin
 POM_NAME=Huawei Publish Gradle Plugin

--- a/plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishExtension.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishExtension.kt
@@ -41,8 +41,6 @@ class HuaweiPublishExtensionConfig(
     var credentialsPath by GradleProperty(project, String::class.java)
  */
     var credentialsPath: String? = null
-    var clientId: String? = null
-    var clientSecret: String? = null
     var deployType: DeployType = DeployType.PUBLISH
     var publishTimeoutMs: Long = DEFAULT_PUBLISH_TIMEOUT_MS
     var publishPeriodMs: Long = DEFAULT_PUBLISH_PERIOD_MS
@@ -55,8 +53,6 @@ class HuaweiPublishExtensionConfig(
         return "HuaweiPublishExtensionConfig(" +
                 "name='$name', " +
                 "credentialsPath='$credentialsPath', " +
-                "clientId='$clientId', " +
-                "clientSecret='$clientSecret', " +
                 "deployType='$deployType', " +
                 "publishTimeoutMs='$publishTimeoutMs', " +
                 "publishPeriodMs='$publishPeriodMs', " +

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
@@ -10,24 +10,28 @@ class HuaweiPublishPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
 
-        check(project.plugins.hasPlugin("com.android.application")) {
-            "Plugin must be applied to the main app plugin but was applied to ${project.path}"
-        }
-
         project.extensions.create(
             HuaweiPublishExtension.MAIN_EXTENSION_NAME,
             HuaweiPublishExtension::class.java,
             project
         )
 
-        project.afterEvaluate {
-            if (!project.plugins.hasPlugin(AppPlugin::class.java)) {
-                project.logger.warn(
-                    "The Android Gradle Plugin was not applied. Gradle Play Publisher " +
-                        "will not be configured.")
-            }
+        val findAppPlugin = { p: Project ->
+            p.plugins.findPlugin(AppPlugin::class.java) != null
         }
 
+        project.afterEvaluate {
+            if (!findAppPlugin(project)) {
+                project.logger.warn(
+                    "The Android Gradle Plugin was not applied. Huawei Publish Plugin " +
+                        "will not be configured."
+                )
+            }
+            applyInternal(project)
+        }
+    }
+
+    private fun applyInternal(project: Project) {
         val androidExtension = project.extensions.getByType(AppExtension::class.java)
         androidExtension.applicationVariants.all { variant ->
             if (!variant.buildType.isDebuggable) {

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
@@ -1,47 +1,34 @@
 package ru.cian.huawei.publish
 
-import com.android.build.gradle.AppExtension
-import com.android.build.gradle.AppPlugin
-import com.android.build.gradle.api.BaseVariant
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.Variant
+import com.android.build.gradle.api.AndroidBasePlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class HuaweiPublishPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
+        project.plugins.withType(AndroidBasePlugin::class.java) {
+            configureHuaweiPublish(project)
+        }
+    }
 
+    private fun configureHuaweiPublish(project: Project) {
         project.extensions.create(
             HuaweiPublishExtension.MAIN_EXTENSION_NAME,
             HuaweiPublishExtension::class.java,
             project
         )
 
-        val findAppPlugin = { p: Project ->
-            p.plugins.findPlugin(AppPlugin::class.java) != null
-        }
-
-        project.afterEvaluate {
-            if (!findAppPlugin(project)) {
-                project.logger.warn(
-                    "The Android Gradle Plugin was not applied. Huawei Publish Plugin " +
-                        "will not be configured."
-                )
-            }
-            applyInternal(project)
-        }
-    }
-
-    private fun applyInternal(project: Project) {
-        val androidExtension = project.extensions.getByType(AppExtension::class.java)
-        androidExtension.applicationVariants.all { variant ->
-            if (!variant.buildType.isDebuggable) {
-                createTask(project, variant)
-            }
+        val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
+        androidComponents.onVariants(androidComponents.selector().withBuildType("release")) { variant ->
+            createTask(project, variant)
         }
     }
 
     @Suppress("DefaultLocale")
-    private fun createTask(project: Project, variant: BaseVariant) {
+    private fun createTask(project: Project, variant: Variant) {
         val variantName = variant.name.capitalize()
         val taskName = "${HuaweiPublishTask.NAME}$variantName"
         project.tasks.create(taskName, HuaweiPublishTask::class.java, variant)

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishTask.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishTask.kt
@@ -1,6 +1,7 @@
 package ru.cian.huawei.publish
 
-import com.android.build.gradle.api.BaseVariant
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.variant.Variant
 import org.gradle.api.DefaultTask
 import org.gradle.api.publish.plugins.PublishingPlugin
 import org.gradle.api.tasks.Internal
@@ -21,12 +22,12 @@ import javax.inject.Inject
 
 open class HuaweiPublishTask
 @Inject constructor(
-    private val variant: BaseVariant
+    private val variant: Variant
 ) : DefaultTask() {
 
     init {
         group = PublishingPlugin.PUBLISH_TASK_GROUP
-        description = "Upload and publish application build file to Huawei AppGallery Store for ${variant.baseName} buildType"
+        description = "Upload and publish application build file to Huawei AppGallery Store for ${variant.name} buildType"
     }
 
     @get:Internal
@@ -89,7 +90,7 @@ open class HuaweiPublishTask
             ?: throw IllegalArgumentException("Plugin extension '${HuaweiPublishExtension.MAIN_EXTENSION_NAME}' is not available at build.gradle of the application module")
 
         val buildTypeName = variant.name
-        val extension = huaweiPublishExtension.instances.find { it.name.toLowerCase() == buildTypeName. toLowerCase() }
+        val extension = huaweiPublishExtension.instances.find { it.name.equals(buildTypeName, ignoreCase = true) }
             ?: throw IllegalArgumentException("Plugin extension '${HuaweiPublishExtension.MAIN_EXTENSION_NAME}' instance with name '$buildTypeName' is not available")
 
         val cli = HuaweiPublishCliParam(
@@ -125,10 +126,13 @@ open class HuaweiPublishTask
         )
 
         Logger.i("Get App ID")
+        val appExtension = project.extensions.getByType(ApplicationExtension::class.java)
+        val applicationId = appExtension.defaultConfig.applicationId
+            ?: throw IllegalStateException("Cannot find the applicationId")
         val appInfo = huaweiService.getAppID(
             clientId = config.credentials.clientId,
             token = token,
-            packageName = variant.applicationId
+            packageName = applicationId
         )
 
         Logger.i("Get Upload Url")

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/service/HttpClientHelper.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/service/HttpClientHelper.kt
@@ -2,68 +2,53 @@ package ru.cian.huawei.publish.service
 
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
-import org.apache.http.Consts
-import org.apache.http.HttpEntity
-import org.apache.http.HttpStatus
-import org.apache.http.client.methods.HttpDelete
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.client.methods.HttpPut
-import org.apache.http.impl.client.HttpClients
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.lang.IllegalStateException
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
 
 internal class HttpClientHelper {
 
+    companion object {
+        val MEDIA_TYPE_JSON = "application/json;charset=utf-8".toMediaType()
+        val MEDIA_TYPE_AAB = "application/octet-stream".toMediaType()
+    }
+
     private val gson by lazy { Gson() }
 
-    fun <T> execute(
-        httpMethod: HttpMethod,
-        url: String,
-        entity: HttpEntity?,
-        headers: Map<String, String>?,
-        clazz: Class<T>
-    ): T {
+    inline fun <reified T> get(url: String, headers: Map<String, String>? = null): T =
+        execute(Request.Builder().get(), url, headers)
 
-        val httpRequest = when (httpMethod) {
-            HttpMethod.GET -> HttpGet(url)
-            HttpMethod.POST -> HttpPost(url)
-            HttpMethod.PUT -> HttpPut(url)
-            HttpMethod.DELETE -> HttpDelete(url)
-        }
+    inline fun <reified T> post(url: String, body: RequestBody, headers: Map<String, String>? = null): T =
+        execute(Request.Builder().post(body), url, headers)
 
-        headers?.forEach {
-            httpRequest.setHeader(it.key, it.value)
-        }
+    inline fun <reified T> put(url: String, body: RequestBody, headers: Map<String, String>? = null): T =
+        execute(Request.Builder().put(body), url, headers)
 
-        if (httpRequest is HttpEntityEnclosingRequestBase) {
-            httpRequest.entity = entity
-        }
-
+    inline fun <reified T> execute(requestBuilder: Request.Builder, url: String, headers: Map<String, String>?): T {
         try {
-            val httpClient = HttpClients.createSystem()
-            val httpResponse = httpClient.execute(httpRequest)
-            val statusCode = httpResponse.statusLine.statusCode
-            if (statusCode == HttpStatus.SC_OK) {
-                val br = BufferedReader(InputStreamReader(httpResponse.entity.content, Consts.UTF_8))
-                val rawResult = br.readLine()
-                val result = gson.fromJson(rawResult, clazz)
+            val client = OkHttpClient()
+            val request = requestBuilder
+                .url(url)
+                .addAllHeaders(headers)
+                .build()
 
-                httpRequest.releaseConnection()
-                httpClient.close()
-
-                if (result == null) {
-                    throw IllegalStateException("http request result must not be null")
+            return client.newCall(request).execute().use { httpResponse ->
+                val statusCode = httpResponse.code
+                if (!httpResponse.isSuccessful) {
+                    throw IllegalStateException("Request failed. statusCode=$statusCode, httpResponse=$httpResponse")
                 }
 
-                return result
+                gson.fromJson(httpResponse.body?.charStream(), T::class.java)
+                    ?: throw IllegalStateException("http request result must not be null")
             }
-            throw IllegalStateException("Request is failed. statusCode=$statusCode, httpResponse=$httpResponse")
         } catch (e: JsonSyntaxException) {
             e.printStackTrace()
         }
         throw IllegalStateException("Request is failed. Something went wrong, please check request!")
+    }
+
+    private fun Request.Builder.addAllHeaders(headers: Map<String, String>?): Request.Builder = this.apply {
+        headers?.forEach { header(it.key, it.value) }
     }
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/service/HttpClientHelper.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/service/HttpClientHelper.kt
@@ -30,7 +30,7 @@ internal class HttpClientHelper {
             val client = OkHttpClient()
             val request = requestBuilder
                 .url(url)
-                .addAllHeaders(headers)
+                .apply { headers?.forEach { header(it.key, it.value) } }
                 .build()
 
             return client.newCall(request).execute().use { httpResponse ->
@@ -46,9 +46,5 @@ internal class HttpClientHelper {
             e.printStackTrace()
         }
         throw IllegalStateException("Request is failed. Something went wrong, please check request!")
-    }
-
-    private fun Request.Builder.addAllHeaders(headers: Map<String, String>?): Request.Builder = this.apply {
-        headers?.forEach { header(it.key, it.value) }
     }
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/BuildFileProvider.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/BuildFileProvider.kt
@@ -1,45 +1,17 @@
 package ru.cian.huawei.publish.utils
 
-import com.android.build.api.artifact.ArtifactType
-import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.internal.api.InstallableVariantImpl
-import com.android.build.gradle.internal.scope.InternalArtifactType
-import org.gradle.api.file.RegularFile
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.Variant
 import ru.cian.huawei.publish.BuildFormat
 import java.io.File
 
-internal class BuildFileProvider(private val variant: BaseVariant) {
+internal class BuildFileProvider(private val variant: Variant) {
 
     fun getBuildFile(buildFormat: BuildFormat): File? {
-        return when(buildFormat) {
-            BuildFormat.APK -> getFinalApkArtifactCompat(variant)
-            BuildFormat.AAB -> getFinalBundleArtifactCompat(variant).singleOrNull()
+        val artifactType = when(buildFormat) {
+            BuildFormat.APK -> SingleArtifact.APK
+            BuildFormat.AAB -> SingleArtifact.BUNDLE
         }
-    }
-
-    private fun getFinalApkArtifactCompat(variant: BaseVariant): File {
-        return variant.outputs.first().outputFile
-    }
-
-    /**
-     * That's hack&trick due to https://issuetracker.google.com/issues/109918868
-     */
-    private fun getFinalBundleArtifactCompat(variant: BaseVariant): Set<File> {
-        val installable = variant as InstallableVariantImpl
-        return try {
-            installable.getFinalArtifact(
-                InternalArtifactType.BUNDLE
-            ).get().files
-        } catch (e: NoClassDefFoundError) {
-            val enumMethod =
-                InternalArtifactType::class.java.getMethod("valueOf", String::class.java)
-            val artifactType = enumMethod.invoke(null, "BUNDLE") as ArtifactType<RegularFile>
-            val artifact = installable.javaClass
-                .getMethod("getFinalArtifact", ArtifactType::class.java)
-                .invoke(installable, artifactType)
-            artifact.javaClass.getMethod("getFiles").apply {
-                isAccessible = true
-            }.invoke(artifact) as Set<File>
-        }
+        return variant.artifacts.get(artifactType).get().asFile
     }
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/ConfigProvider.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/ConfigProvider.kt
@@ -76,8 +76,8 @@ internal class ConfigProvider(
 
     fun getCredentialsConfig(): Credentials {
         val credentialsFilePath = cli.credentialsPath ?: extension.credentialsPath
-        val clientIdPriority: String? = cli.clientId ?: extension.clientId
-        val clientSecretPriority: String? = cli.clientSecret ?: extension.clientSecret
+        val clientIdPriority: String? = cli.clientId
+        val clientSecretPriority: String? = cli.clientSecret
         val credentials = lazy {
             if (credentialsFilePath.isNullOrBlank()) {
                 throw FileNotFoundException(

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/ConfigProvider.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/ConfigProvider.kt
@@ -1,18 +1,13 @@
 package ru.cian.huawei.publish.utils
 
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
-import com.google.gson.stream.JsonReader
 import ru.cian.huawei.publish.BuildFormat
 import ru.cian.huawei.publish.Credentials
 import ru.cian.huawei.publish.HuaweiPublishCliParam
 import ru.cian.huawei.publish.HuaweiPublishConfig
 import ru.cian.huawei.publish.HuaweiPublishExtensionConfig
 import ru.cian.huawei.publish.ReleasePhaseConfig
-import ru.cian.huawei.publish.models.*
 import java.io.File
 import java.io.FileNotFoundException
-import java.io.FileReader
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -92,7 +87,7 @@ internal class ConfigProvider(
                             "with 'client_id' and 'client_secret' for access to Huawei Publish API is not found)"
                 )
             }
-            getCredentials(credentialsFile)
+            CredentialHelper.getCredentials(credentialsFile)
         }
         val clientId = clientIdPriority ?: credentials.value.clientId.nullIfBlank()
         ?: throw IllegalArgumentException(
@@ -152,12 +147,6 @@ internal class ConfigProvider(
             }
         }
         return releasePhase
-    }
-
-    fun getCredentials(credentialsFile: File): Credential {
-        val reader = JsonReader(FileReader(credentialsFile.absolutePath))
-        val type = object : TypeToken<Credential>() {}.type
-        return Gson().fromJson(reader, type)
     }
 
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/CredentialHelper.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/CredentialHelper.kt
@@ -1,0 +1,16 @@
+package ru.cian.huawei.publish.utils
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import ru.cian.huawei.publish.models.Credential
+import java.io.File
+import java.io.FileReader
+
+internal object CredentialHelper {
+    fun getCredentials(credentialsFile: File): Credential {
+        val reader = JsonReader(FileReader(credentialsFile.absolutePath))
+        val type = object : TypeToken<Credential>() {}.type
+        return Gson().fromJson(reader, type)
+    }
+}

--- a/sample-aar/build.gradle
+++ b/sample-aar/build.gradle
@@ -1,0 +1,56 @@
+apply plugin: 'com.android.library'
+apply plugin: 'ru.cian.huawei-publish'
+apply from: "$rootDir/dependencies.gradle"
+
+buildscript {
+    repositories {
+        mavenCentral()
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+    }
+
+    dependencies {
+        classpath "ru.cian:huawei-publish-gradle-plugin:" + sample.huaweiPlugin
+    }
+}
+
+huaweiPublish {
+    instances {
+        release {
+            credentialsPath = "$rootDir/sample2/huawei-credentials-1.json"
+            deployType = "upload-only"
+            buildFormat = "aab"
+        }
+    }
+}
+
+android {
+    compileSdkVersion config.compileSdkVersion
+    buildToolsVersion config.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            debuggable false
+        }
+        debug {
+            debuggable true
+        }
+    }
+
+    flavorDimensions "version"
+    lintOptions {
+        abortOnError false
+    }
+}
+
+beforeEvaluate {
+    println("-------------------------------------------------------------------------")
+    println("Should get error!")
+    println("-------------------------------------------------------------------------")
+}

--- a/sample-aar/huawei-credentials-1.json
+++ b/sample-aar/huawei-credentials-1.json
@@ -1,0 +1,4 @@
+{
+  "client_id": "<CLIENT_ID>",
+  "client_secret": "<CLIENT_SECRET>"
+}

--- a/sample-aar/src/main/res/values/strings.xml
+++ b/sample-aar/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Huawei Plugin Sample-AAR</string>
+    <string name="hello_text">Hello World\nfrom Sample-AAR app</string>
+</resources>

--- a/sample1/build.gradle
+++ b/sample1/build.gradle
@@ -1,17 +1,10 @@
-apply plugin: 'com.android.application'
-apply plugin: 'ru.cian.huawei-publish'
-apply from: "$rootDir/dependencies.gradle"
-
-buildscript {
-    repositories {
-        mavenCentral()
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
-    }
-
-    dependencies {
-        classpath "ru.cian:huawei-publish-gradle-plugin:" + sample.huaweiPlugin
-    }
+plugins {
+    id("com.android.application")
+    id("com.ofg.uptodate")
+    id("ru.cian.huawei-publish")
 }
+
+apply(from: "$rootDir/dependencies.gradle")
 
 huaweiPublish {
     instances {
@@ -32,32 +25,32 @@ android {
     buildToolsVersion config.buildToolsVersion
 
     defaultConfig {
-        applicationId "ru.cian.huawei.sample1"
-        minSdkVersion config.minSdkVersion
-        targetSdkVersion config.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        applicationId = "ru.cian.huawei.sample1"
+        minSdkVersion(config.minSdkVersion)
+        targetSdkVersion(config.targetSdkVersion)
+        versionCode = 1
+        versionName = "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
         release {
-            minifyEnabled false
-            debuggable false
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            minifyEnabled = false
+            debuggable = false
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
         debug {
-            debuggable true
-            applicationIdSuffix ".debug"
-            versionNameSuffix "-debug"
+            debuggable = true
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-debug"
         }
     }
     lintOptions {
-        abortOnError false
+        abortOnError = false
     }
 }
 
 dependencies {
-    implementation libs.appcompat
+    implementation (libs.appcompat)
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,0 @@
-rootProject.name='Huawei Publish Gradle Plugin'
-
-includeBuild ("plugin")
-
-include(":sample1")
-include(":sample2")
-

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,37 @@
+rootProject.name = "Huawei Publish Gradle Plugin"
+
+includeBuild (
+    "plugin"
+)
+
+include(
+    ":sample1",
+    ":sample2"
+//    ":sample-aar" // For uncomment should get error at sync project time as well;
+)
+
+pluginManagement {
+
+    val huaweiPublish = "1.2.4-SNAPSHOT"
+
+    resolutionStrategy {
+        eachPlugin {
+            if(requested.id.namespace == "ru.cian") {
+                useModule("ru.cian:huawei-publish-gradle-plugin:${huaweiPublish}")
+            }
+        }
+    }
+
+    plugins {
+        id("com.ofg.uptodate") version "1.6.3" apply false
+        id("ru.cian.huawei-publish") version huaweiPublish apply false
+    }
+
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+        jcenter()
+    }
+
+}


### PR DESCRIPTION
- Gradle 7.0 support
- AGP 7.0 support
- `org.apache.http` is not bundled in build tools anymore, so replaced that with OkHttp
- fixed unit tests
- added github actions for automated testing

closes #25 

note:
some additional changes come from the fact that `develop` is behind `master` a few commits