### PR TITLE
Add support for Gradle 7.0 and AGP 7.0

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,28 @@
+name: All tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        kotlin-version: [1.4.21, 1.5.21]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run tests with Gradle
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: :plugin:test --stacktrace -Pkotlin.version=${{ matrix.kotlin-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.3.0
 
 ##### Add
-* [issue#25](https://github.com/cianru/huawei-publish-gradle-plugin/issues/21):
+* [issue#25](https://github.com/cianru/huawei-publish-gradle-plugin/issues/25):
 Gradle 7.0 / Android Gradle Plugin 7.0 support
 * add unit tests to automated github actions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.3.0
+
+##### Add
+* [issue#25](https://github.com/cianru/huawei-publish-gradle-plugin/issues/21):
+Gradle 7.0 / Android Gradle Plugin 7.0 support
+* add unit tests to automated github actions
+
 # 1.2.4
 
 ##### Add

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://img.shields.io/maven-central/v/ru.cian/huawei-publish-gradle-plugin.svg)](https://search.maven.org/search?q=a:huawei-publish-gradle-plugin)
 ![Version](https://img.shields.io/badge/Version-1.2.4-green.svg)
-![Version](https://img.shields.io/badge/Gradle-4.1.*-pink.svg)
+![Version](https://img.shields.io/badge/Gradle-7.0.*-pink.svg)
 [![License](https://img.shields.io/github/license/srs/gradle-node-plugin.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 
 The plugin allows you to publish the android release build file (*.apk or *.aab) to the Huawei AppGallery.
@@ -18,12 +18,12 @@ The following features are available:
 * Publish the build on a part of users (Release Phases)
 * Separated settings for different configurations build types and flavors
 * Support of Gradle Portal and Gradle DSL.
+* Support of Gradle 7.+
 
 The following features are missing:
 
 * Change App Store Information: description, app icon, screenshots and etc.
 * Add Release Notes for publishing build.
-* Support of Gradle 7.+
 * Support of Configuration Cache
 
 # Adding the plugin to your project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,7 @@ buildscript {
     }
 
     dependencies {
-//        classpath(Dependencies.gradlePlugins.gradle)
-        classpath("com.android.tools.build:gradle:4.1.3")
+        classpath("com.android.tools.build:gradle:7.0.0")
     }
 }
 
@@ -35,13 +34,10 @@ configurations.all {
 }
 
 dependencies {
-    "implementation" (Dependencies.libs.kotlinStdlib)
-    "implementation" (Dependencies.libs.kotlinReflect)
-    "implementation" (Dependencies.libs.gson)
+    implementation(Dependencies.libs.kotlinStdlib)
+    implementation(Dependencies.libs.kotlinReflect)
+    implementation(Dependencies.libs.gson)
+    implementation(Dependencies.libs.okHttp)
 
-    "compileOnly" (Dependencies.gradlePlugins.gradle)
+    compileOnly(Dependencies.gradlePlugins.gradle)
 }
-
-//tasks.register("clean", Delete::class) {
-//    delete(rootProject.buildDir)
-//}

--- a/buildSrc/src/main/kotlin/ru/cian/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/ru/cian/Dependencies.kt
@@ -2,7 +2,7 @@ package ru.cian
 
 object Dependencies {
 
-    const val gradle = "com.android.tools.build:gradle:4.1.3"
+    const val gradle = "com.android.tools.build:gradle:7.0.0"
 
     object android {
         const val compileSdkVersion = 30
@@ -22,6 +22,7 @@ object Dependencies {
         const val kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
         const val kotlinReflect = "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
         const val gson = "com.google.code.gson:gson:2.8.6"
+        const val okHttp = "com.squareup.okhttp3:okhttp:4.9.1"
     }
 
     object junit {
@@ -36,7 +37,7 @@ object Dependencies {
     }
 
     object gradlePlugins {
-        const val gradle = "com.android.tools.build:gradle:4.1.3"
+        const val gradle = "com.android.tools.build:gradle:7.0.0"
     }
 
     object sample {

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -26,18 +26,20 @@ repositories {
 }
 
 dependencies {
-    "implementation"(Dependencies.libs.kotlinStdlib)
-    "implementation"(Dependencies.libs.kotlinReflect)
-    "implementation"(Dependencies.libs.gson)
+    implementation(Dependencies.libs.kotlinStdlib)
+    implementation(Dependencies.libs.kotlinReflect)
+    implementation(Dependencies.libs.gson)
+    implementation(Dependencies.libs.okHttp)
 
-    "compileOnly"(Dependencies.gradlePlugins.gradle)
+    compileOnly(Dependencies.gradlePlugins.gradle)
 
-    "testImplementation"(Dependencies.junit.junitJupiterApi)
-    "testImplementation"(Dependencies.junit.junitJupiterEngine)
-    "testImplementation"(Dependencies.junit.junitJupiterParams)
-    "testImplementation"(Dependencies.junit.mockk)
-    "testImplementation"(Dependencies.junit.mockito)
-    "testImplementation"(Dependencies.junit.mockitoKotlin)
-    "testImplementation"(Dependencies.junit.hamcreast)
-    "testImplementation"(Dependencies.junit.assertk)
+    testImplementation(Dependencies.junit.junitJupiterApi)
+    testImplementation(Dependencies.junit.junitJupiterEngine)
+    testImplementation(Dependencies.junit.junitJupiterParams)
+    testImplementation(Dependencies.junit.mockk)
+    testImplementation(Dependencies.junit.mockito)
+    testImplementation(Dependencies.junit.mockitoKotlin)
+    testImplementation(Dependencies.junit.hamcreast)
+    testImplementation(Dependencies.junit.assertk)
+    testImplementation(Dependencies.gradlePlugins.gradle)
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -18,6 +18,10 @@ tasks.withType<org.jetbrains.dokka.gradle.DokkaTask>().configureEach {
     outputDirectory.set(buildDir.resolve("dokka"))
 }
 
+tasks.withType<Test> {
+    useJUnitPlatform {}
+}
+
 repositories {
     google()
     mavenCentral()

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishPlugin.kt
@@ -1,62 +1,36 @@
 package ru.cian.huawei.publish
 
-import com.android.build.api.variant.ApplicationVariantProperties
-import com.android.build.gradle.AppPlugin
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.Variant
+import com.android.build.gradle.api.AndroidBasePlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.ExtensionAware
-import org.gradle.kotlin.dsl.container
-import org.gradle.kotlin.dsl.the
-import org.gradle.kotlin.dsl.withType
-import ru.cian.huawei.publish.utils.Logger
 
 class HuaweiPublishPlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
+        project.plugins.withType(AndroidBasePlugin::class.java) {
+            configureHuaweiPublish(project)
+        }
+    }
 
+    private fun configureHuaweiPublish(project: Project) {
         project.extensions.create(
             HuaweiPublishExtension.MAIN_EXTENSION_NAME,
             HuaweiPublishExtension::class.java,
             project
         )
 
-        project.plugins.withType<AppPlugin> {
-            applyInternal(project)
-        }
-
-        project.afterEvaluate {
-            if (project.plugins.findPlugin(AppPlugin::class.java) == null) {
-                project.logger.warn(
-                    "The Android Gradle Plugin was not applied. Huawei Publish Plugin " +
-                        "will not be configured."
-                )
-            }
-        }
-    }
-
-    private fun applyInternal(project: Project) {
-
-        val PLAY_CONFIGS_PATH = "huaweiConfigs"
-        val extensionContainer = project.container<HuaweiPublishExtension>()
-        val android = project.the<BaseAppModuleExtension>()
-        (android as ExtensionAware).extensions.add(PLAY_CONFIGS_PATH, extensionContainer)
-
-        android.onVariants v@{
-            project.logger.debug("${Logger.LOG_TAG}: Found variant=${name}, flavor=${flavorName}, buildType=${buildType}")
-            onProperties p@{
-                if (!debuggable) {
-                    createTask(project, this)
-                }
-            }
+        val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
+        androidComponents.onVariants(androidComponents.selector().withBuildType("release")) { variant ->
+            createTask(project, variant)
         }
     }
 
     @Suppress("DefaultLocale")
-    private fun createTask(project: Project, variant: ApplicationVariantProperties) {
+    private fun createTask(project: Project, variant: Variant) {
         val variantName = variant.name.capitalize()
         val taskName = "${HuaweiPublishTask.NAME}$variantName"
-        project.logger.debug("${Logger.LOG_TAG}: createTask: $taskName")
         project.tasks.create(taskName, HuaweiPublishTask::class.java, variant)
     }
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishTask.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/HuaweiPublishTask.kt
@@ -1,7 +1,7 @@
 package ru.cian.huawei.publish
 
-import com.android.build.api.variant.ApplicationVariantProperties
-import com.android.build.gradle.api.BaseVariant
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.variant.Variant
 import org.gradle.api.DefaultTask
 import org.gradle.api.publish.plugins.PublishingPlugin
 import org.gradle.api.tasks.Internal
@@ -22,12 +22,12 @@ import javax.inject.Inject
 
 open class HuaweiPublishTask
 @Inject constructor(
-    private val variant: ApplicationVariantProperties
+    private val variant: Variant
 ) : DefaultTask() {
 
     init {
         group = PublishingPlugin.PUBLISH_TASK_GROUP
-        description = "Upload and publish application build file to Huawei AppGallery Store for `${variant.name}` buildType"
+        description = "Upload and publish application build file to Huawei AppGallery Store for ${variant.name} buildType"
     }
 
     @get:Internal
@@ -126,10 +126,13 @@ open class HuaweiPublishTask
         )
 
         Logger.i("Get App ID")
+        val appExtension = project.extensions.getByType(ApplicationExtension::class.java)
+        val applicationId = appExtension.defaultConfig.applicationId
+            ?: throw IllegalStateException("Cannot find the applicationId")
         val appInfo = huaweiService.getAppID(
             clientId = config.credentials.clientId,
             token = token,
-            packageName = variant.applicationId.get()
+            packageName = applicationId
         )
 
         Logger.i("Get Upload Url")

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/service/HttpClientHelper.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/service/HttpClientHelper.kt
@@ -2,68 +2,53 @@ package ru.cian.huawei.publish.service
 
 import com.google.gson.Gson
 import com.google.gson.JsonSyntaxException
-import org.apache.http.Consts
-import org.apache.http.HttpEntity
-import org.apache.http.HttpStatus
-import org.apache.http.client.methods.HttpDelete
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase
-import org.apache.http.client.methods.HttpGet
-import org.apache.http.client.methods.HttpPost
-import org.apache.http.client.methods.HttpPut
-import org.apache.http.impl.client.HttpClients
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.lang.IllegalStateException
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
 
 internal class HttpClientHelper {
 
+    companion object {
+        val MEDIA_TYPE_JSON = "application/json;charset=utf-8".toMediaType()
+        val MEDIA_TYPE_AAB = "application/octet-stream".toMediaType()
+    }
+
     private val gson by lazy { Gson() }
 
-    fun <T> execute(
-        httpMethod: HttpMethod,
-        url: String,
-        entity: HttpEntity?,
-        headers: Map<String, String>?,
-        clazz: Class<T>
-    ): T {
+    inline fun <reified T> get(url: String, headers: Map<String, String>? = null): T =
+        execute(Request.Builder().get(), url, headers)
 
-        val httpRequest = when (httpMethod) {
-            HttpMethod.GET -> HttpGet(url)
-            HttpMethod.POST -> HttpPost(url)
-            HttpMethod.PUT -> HttpPut(url)
-            HttpMethod.DELETE -> HttpDelete(url)
-        }
+    inline fun <reified T> post(url: String, body: RequestBody, headers: Map<String, String>? = null): T =
+        execute(Request.Builder().post(body), url, headers)
 
-        headers?.forEach {
-            httpRequest.setHeader(it.key, it.value)
-        }
+    inline fun <reified T> put(url: String, body: RequestBody, headers: Map<String, String>? = null): T =
+        execute(Request.Builder().put(body), url, headers)
 
-        if (httpRequest is HttpEntityEnclosingRequestBase) {
-            httpRequest.entity = entity
-        }
-
+    inline fun <reified T> execute(requestBuilder: Request.Builder, url: String, headers: Map<String, String>?): T {
         try {
-            val httpClient = HttpClients.createSystem()
-            val httpResponse = httpClient.execute(httpRequest)
-            val statusCode = httpResponse.statusLine.statusCode
-            if (statusCode == HttpStatus.SC_OK) {
-                val br = BufferedReader(InputStreamReader(httpResponse.entity.content, Consts.UTF_8))
-                val rawResult = br.readLine()
-                val result = gson.fromJson(rawResult, clazz)
+            val client = OkHttpClient()
+            val request = requestBuilder
+                .url(url)
+                .addAllHeaders(headers)
+                .build()
 
-                httpRequest.releaseConnection()
-                httpClient.close()
-
-                if (result == null) {
-                    throw IllegalStateException("http request result must not be null")
+            return client.newCall(request).execute().use { httpResponse ->
+                val statusCode = httpResponse.code
+                if (!httpResponse.isSuccessful) {
+                    throw IllegalStateException("Request failed. statusCode=$statusCode, httpResponse=$httpResponse")
                 }
 
-                return result
+                gson.fromJson(httpResponse.body?.charStream(), T::class.java)
+                    ?: throw IllegalStateException("http request result must not be null")
             }
-            throw IllegalStateException("Request is failed. statusCode=$statusCode, httpResponse=$httpResponse")
         } catch (e: JsonSyntaxException) {
             e.printStackTrace()
         }
         throw IllegalStateException("Request is failed. Something went wrong, please check request!")
+    }
+
+    private fun Request.Builder.addAllHeaders(headers: Map<String, String>?): Request.Builder = this.apply {
+        headers?.forEach { header(it.key, it.value) }
     }
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/service/HttpClientHelper.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/service/HttpClientHelper.kt
@@ -30,7 +30,7 @@ internal class HttpClientHelper {
             val client = OkHttpClient()
             val request = requestBuilder
                 .url(url)
-                .addAllHeaders(headers)
+                .apply { headers?.forEach { header(it.key, it.value) } }
                 .build()
 
             return client.newCall(request).execute().use { httpResponse ->
@@ -46,9 +46,5 @@ internal class HttpClientHelper {
             e.printStackTrace()
         }
         throw IllegalStateException("Request is failed. Something went wrong, please check request!")
-    }
-
-    private fun Request.Builder.addAllHeaders(headers: Map<String, String>?): Request.Builder = this.apply {
-        headers?.forEach { header(it.key, it.value) }
     }
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/BuildFileProvider.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/BuildFileProvider.kt
@@ -1,33 +1,17 @@
 package ru.cian.huawei.publish.utils
 
-import com.android.build.api.artifact.ArtifactType
-import com.android.build.api.variant.ApplicationVariantProperties
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.Variant
 import ru.cian.huawei.publish.BuildFormat
 import java.io.File
 
-internal class BuildFileProvider(private val variant: ApplicationVariantProperties) {
+internal class BuildFileProvider(private val variant: Variant) {
 
     fun getBuildFile(buildFormat: BuildFormat): File? {
-        return when(buildFormat) {
-            BuildFormat.APK -> getFinalApkArtifactCompat(variant)
-            BuildFormat.AAB -> getFinalBundleArtifactCompat(variant)
+        val artifactType = when(buildFormat) {
+            BuildFormat.APK -> SingleArtifact.APK
+            BuildFormat.AAB -> SingleArtifact.BUNDLE
         }
-    }
-
-    private fun getFinalApkArtifactCompat(variant: ApplicationVariantProperties): File? {
-        val artifacts = variant.artifacts
-        val artifactType = artifacts.get(ArtifactType.APK).get()
-        val sneakyNull = artifacts.getBuiltArtifactsLoader()
-            .load(artifactType)?.elements?.map { it.outputFile } ?: return null
-        return File(sneakyNull.first())
-    }
-
-    /**
-     * That's hack&trick due to https://issuetracker.google.com/issues/109918868
-     */
-    private fun getFinalBundleArtifactCompat(variant: ApplicationVariantProperties): File? {
-        val artifactType = variant.artifacts.get(ArtifactType.BUNDLE)
-        val filePath = artifactType.get().asFile.absolutePath ?: return null
-        return File(filePath)
+        return variant.artifacts.get(artifactType).get().asFile
     }
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/ConfigProvider.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/ConfigProvider.kt
@@ -1,18 +1,13 @@
 package ru.cian.huawei.publish.utils
 
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
-import com.google.gson.stream.JsonReader
 import ru.cian.huawei.publish.BuildFormat
 import ru.cian.huawei.publish.Credentials
 import ru.cian.huawei.publish.HuaweiPublishCliParam
 import ru.cian.huawei.publish.HuaweiPublishConfig
 import ru.cian.huawei.publish.HuaweiPublishExtensionConfig
 import ru.cian.huawei.publish.ReleasePhaseConfig
-import ru.cian.huawei.publish.models.Credential
 import java.io.File
 import java.io.FileNotFoundException
-import java.io.FileReader
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -93,7 +88,7 @@ internal class ConfigProvider(
                             "with 'client_id' and 'client_secret' for access to Huawei Publish API is not found)"
                 )
             }
-            getCredentials(credentialsFile)
+            CredentialHelper.getCredentials(credentialsFile)
         }
         val clientId = clientIdPriority ?: credentials.value.clientId.nullIfBlank()
         ?: throw IllegalArgumentException(
@@ -153,12 +148,6 @@ internal class ConfigProvider(
             }
         }
         return releasePhase
-    }
-
-    fun getCredentials(credentialsFile: File): Credential {
-        val reader = JsonReader(FileReader(credentialsFile.absolutePath))
-        val type = object : TypeToken<Credential>() {}.type
-        return Gson().fromJson(reader, type)
     }
 
 }

--- a/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/CredentialHelper.kt
+++ b/plugin/src/main/kotlin/ru/cian/huawei/publish/utils/CredentialHelper.kt
@@ -1,0 +1,16 @@
+package ru.cian.huawei.publish.utils
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.google.gson.stream.JsonReader
+import ru.cian.huawei.publish.models.Credential
+import java.io.File
+import java.io.FileReader
+
+internal object CredentialHelper {
+    fun getCredentials(credentialsFile: File): Credential {
+        val reader = JsonReader(FileReader(credentialsFile.absolutePath))
+        val type = object : TypeToken<Credential>() {}.type
+        return Gson().fromJson(reader, type)
+    }
+}

--- a/sample-kotlin/build.gradle.kts
+++ b/sample-kotlin/build.gradle.kts
@@ -23,13 +23,13 @@ huaweiPublish {
 }
 
 android {
-    compileSdkVersion(Dependencies.android.compileSdkVersion)
-    buildToolsVersion(Dependencies.android.buildToolsVersion)
+    compileSdk = Dependencies.android.compileSdkVersion
+    buildToolsVersion = Dependencies.android.buildToolsVersion
 
     defaultConfig {
         applicationId = "ru.cian.huawei.sample_kotlin"
-        minSdkVersion(Dependencies.android.minSdkVersion)
-        targetSdkVersion(Dependencies.android.targetSdkVersion)
+        minSdk = Dependencies.android.minSdkVersion
+        targetSdk = Dependencies.android.targetSdkVersion
         versionCode = 1
         versionName = "1.0"
 
@@ -38,17 +38,17 @@ android {
 
     buildTypes {
         getByName("release") {
-            minifyEnabled(false)
-            debuggable(false)
+            isMinifyEnabled = false
+            isDebuggable = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
         getByName("debug") {
-            debuggable(true)
+            isDebuggable = true
             applicationIdSuffix = ".debug"
             versionNameSuffix = "-debug"
         }
     }
-    lintOptions {
+    lint {
         isAbortOnError = false
     }
     compileOptions {
@@ -64,5 +64,5 @@ configurations {
 }
 
 dependencies {
-    "implementation"(Dependencies.libs.appcompat)
+    implementation(Dependencies.libs.appcompat)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ pluginManagement {
 
     plugins {
         id("ru.cian.huawei-publish") version huaweiPublish apply false
-        id("com.android.tools.build") version "4.1.3" apply false
+        id("com.android.tools.build") version "7.0.0" apply false
         id("org.jetbrains.dokka") version "1.4.30" apply false
         id("com.github.dcendents") version "plugin:2.1" apply false
         id("com.jfrog.bintray") version "1.8.5" apply false


### PR DESCRIPTION
- Gradle 7.0 support
- AGP 7.0 support
- `org.apache.http` is not bundled in build tools anymore, so replaced that with OkHttp
- fixed unit tests
- added github actions for automated testing

closes #25